### PR TITLE
lock down aws/aws-sdk-php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+## 2.1.X - 2021-03-22
+* require `aws/aws-sdk-php` and use fixed version: `3.173.23` 
+
 ## 2.1.0 - 2021-03-03
 
 * Allow PHP ^8.0

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "php": "^7.3.0|^8.0",
     "craftcms/cms": "^3.5.15",
     "league/flysystem-aws-s3-v3": "^1.0.18",
+    "aws/aws-sdk-php": "<= 3.173.23",
     "symfony/console": "^5.1"
   },
   "autoload": {


### PR DESCRIPTION
Lock down `aws/aws-sdk-php` to prevent issue with latest version

https://github.com/fortrabbit/craft-object-storage/issues/15