### PR TITLE
Change API endpoint protocol validation

### DIFF
--- a/src/Volume.php
+++ b/src/Volume.php
@@ -120,6 +120,10 @@ class Volume extends FlysystemVolume
     {
         $endpoint = Craft::parseEnv($this->endpoint);
 
+        if (strpos($endpoint, 'http') === false) {
+            $endpoint = 'https://' .  $endpoint;
+        }
+        
         $config = [
             'version'      => 'latest',
             'region'       => Craft::parseEnv($this->region),

--- a/src/Volume.php
+++ b/src/Volume.php
@@ -120,10 +120,6 @@ class Volume extends FlysystemVolume
     {
         $endpoint = Craft::parseEnv($this->endpoint);
 
-        if (strpos($endpoint, 'https') === false) {
-            $endpoint = 'https://' .  $endpoint;
-        }
-
         $config = [
             'version'      => 'latest',
             'region'       => Craft::parseEnv($this->region),

--- a/src/Volume.php
+++ b/src/Volume.php
@@ -123,7 +123,7 @@ class Volume extends FlysystemVolume
         if (strpos($endpoint, 'http') === false) {
             $endpoint = 'https://' .  $endpoint;
         }
-        
+
         $config = [
             'version'      => 'latest',
             'region'       => Craft::parseEnv($this->region),


### PR DESCRIPTION
# Before
If the server API endpoint did not start with 'https' then 'https://' was prepended.

# Now
If the server API endpoint does not start with 'http' nor with 'https' then 'https://' is prepended.

# Why?
HTTP API endpoints were not allowed before, now they are.